### PR TITLE
Add missing ruby version Gemfile setting

### DIFF
--- a/dummy_app/Gemfile
+++ b/dummy_app/Gemfile
@@ -1,4 +1,6 @@
 source "https://rubygems.org"
 
+ruby '2.6.6'
+
 gem 'puma'
 gem 'sinatra'


### PR DESCRIPTION
Hi Robert!

Thanks for the handy fork!

I've just noticed that the dummy_app is a bit outdated.
Heroku doesn't allow a Gemfile with missing `ruby` version setting.

```
remote:        Bundle complete! 2 Gemfile dependencies, 7 gems now installed.
remote:        Gems in the groups development and test were not installed.
remote:        Bundled gems are installed into `./vendor/bundle`
remote:        Bundle completed (3.77s)
remote:        Cleaning up the bundler cache.
remote: -----> Detecting rake tasks
remote:
remote: ###### WARNING:
remote:
remote:        You have not declared a Ruby version in your Gemfile.
remote:
remote:        To declare a Ruby version add this line to your Gemfile:
remote:
remote:        ```
remote:        ruby "2.6.6"
remote:        ```
remote:
remote:        For more information see:
remote:          https://devcenter.heroku.com/articles/ruby-versions
```

After the fix it all went through.

HTH